### PR TITLE
FIX: dependency tag/version synch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "webtorrent",
   "description": "Streaming torrent client",
-  "version": "0.107.3-arc-5",
+  "version": "0.107.3-arc-6",
   "author": {
     "name": "WebTorrent, LLC",
     "email": "feross@webtorrent.io",
@@ -68,7 +68,7 @@
     "stream-to-blob": "^2.0.0",
     "stream-to-blob-url": "^3.0.0",
     "stream-with-known-length-to-buffer": "^1.0.0",
-    "torrent-discovery": "git+https://github.com/guanzo/torrent-discovery.git#v9.2.0-arc-3",
+    "torrent-discovery": "git+https://github.com/guanzo/torrent-discovery.git#v9.2.0-arc-6",
     "torrent-piece": "^2.0.0",
     "uniq": "^1.0.1",
     "unordered-array-remove": "^1.0.2",


### PR DESCRIPTION
Bittorrent-tracker version and tag were out of synch, failing dependency checks.